### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ list affects the assigned network numbers, so when making changes later it's
 important to take care to avoid implicitly renumbering other networks.
 
 The safest approach is to only add new networks to the end of the list and
-to never remove an existing network or or change its `new_bits` value. If
+to never remove an existing network or change its `new_bits` value. If
 an existing allocation becomes obsolute, you can set its name explicitly to
 `null` to skip allocating it a prefix but to retain the space it previously
 occupied in the address space:
@@ -342,7 +342,7 @@ You can create a CSV file `subnets.csv` containing the following and place
 it inside your own calling module:
 
 ```
-"name","newbits"
+"name","new_bits"
 "foo","8"
 "","8"
 "baz","8"


### PR DESCRIPTION
Fix typo "or or".
Fix typo on CVS header which is missing an underscore.